### PR TITLE
Add MDX support for articles

### DIFF
--- a/src/app/(frontend)/articles/[tutorial_slug]/components/article-content.tsx
+++ b/src/app/(frontend)/articles/[tutorial_slug]/components/article-content.tsx
@@ -2,6 +2,9 @@ import { Markdown } from './markdown'
 import { RecommendedArticles } from '@/components/recommended-articles'
 import { TypographyH1, TypographyP } from '@/components/typography'
 import { Article as PayloadArticle } from '@/payload-types'
+import { serialize } from 'next-mdx-remote/serialize'
+import { MarkdownRemote } from '@/components/MarkdownMDX'
+import { getArticleMDXComponents } from '@/article-mdx-components'
 
 interface ArticleContentProps {
   article: PayloadArticle
@@ -10,12 +13,18 @@ interface ArticleContentProps {
   tutorial_slug: string
 }
 
-export const ArticleContent = ({
+export const ArticleContent = async ({
   article,
   popularArticles,
   personalizedArticles,
   tutorial_slug,
 }: ArticleContentProps) => {
+  let mdxSource = null
+  try {
+    mdxSource = await serialize(article.content)
+  } catch (error) {
+    console.error('MDX serialization failed, falling back to Markdown', error)
+  }
   return (
     <main className="flex w-full min-w-0 flex-col">
       <div className="flex w-full flex-1 flex-col gap-6 px-4 pt-8 pb-12 md:px-6 md:pt-12 xl:px-12 xl:mx-auto max-w-[860px]">
@@ -23,7 +32,11 @@ export const ArticleContent = ({
           <TypographyH1>{article.title}</TypographyH1>
           {article.subtitle && <TypographyP>{article.subtitle}</TypographyP>}
           {/* Article content */}
-          <Markdown>{article.content}</Markdown>
+          {mdxSource ? (
+            <MarkdownRemote source={mdxSource} components={getArticleMDXComponents()} />
+          ) : (
+            <Markdown>{article.content}</Markdown>
+          )}
         </article>
         <RecommendedArticles
           popularArticles={popularArticles}

--- a/src/article-mdx-components.tsx
+++ b/src/article-mdx-components.tsx
@@ -1,0 +1,152 @@
+import { CodeBlock, CodeBlockCode } from '@/components/code-block'
+import {
+  TypographyH1,
+  TypographyH2,
+  TypographyH3,
+  TypographyP,
+  TypographyBlockquote,
+  TypographyList,
+  TypographyLink,
+  TypographyInlineCode,
+  TypographyBold,
+  TypographyItalic,
+} from '@/components/typography'
+import type { ReactNode, ComponentType } from 'react'
+
+function slugify(text: string): string {
+  return text.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '')
+}
+
+function extractLanguage(className?: string): string {
+  if (!className) return 'plaintext'
+  const match = className.match(/language-(\w+)/)
+  return match ? match[1] : 'plaintext'
+}
+
+interface TypographyProps {
+  children: ReactNode
+  className?: string
+  id?: string
+}
+
+function TypographyPWrapper({ children, className = '', id }: TypographyProps) {
+  return (
+    <p id={id} className={`leading-7 [&:not(:first-child)]:mt-6 ${className} text-muted-foreground`}>
+      {children}
+    </p>
+  )
+}
+
+const DEFAULT_ARTICLE_MDX_COMPONENTS: Record<string, ComponentType<any>> = {
+  h1: function H1({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH1 id={id} {...props}>
+        {children}
+      </TypographyH1>
+    )
+  },
+  h2: function H2({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH2 id={id} {...props}>
+        {children}
+      </TypographyH2>
+    )
+  },
+  h3: function H3({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH3 id={id} {...props}>
+        {children}
+      </TypographyH3>
+    )
+  },
+  h4: function H4({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH3 id={id} className="text-lg" {...props}>
+        {children}
+      </TypographyH3>
+    )
+  },
+  h5: function H5({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH3 id={id} className="text-base" {...props}>
+        {children}
+      </TypographyH3>
+    )
+  },
+  h6: function H6({ children, ...props }) {
+    const id = typeof children === 'string' ? slugify(children) : ''
+    return (
+      <TypographyH3 id={id} className="text-sm" {...props}>
+        {children}
+      </TypographyH3>
+    )
+  },
+  p: function P({ children, ...props }) {
+    return <TypographyPWrapper {...props}>{children}</TypographyPWrapper>
+  },
+  blockquote: function Blockquote({ children, ...props }) {
+    return <TypographyBlockquote {...props}>{children}</TypographyBlockquote>
+  },
+  ul: function Ul({ children, ...props }) {
+    return (
+      <TypographyList {...props} className="text-muted-foreground">
+        {children}
+      </TypographyList>
+    )
+  },
+  ol: function Ol({ children, ...props }) {
+    return (
+      <TypographyList {...props} className="list-decimal text-muted-foreground">
+        {children}
+      </TypographyList>
+    )
+  },
+  a: function A({ children, href, ...props }) {
+    return (
+      <TypographyLink href={href} {...props}>
+        {children}
+      </TypographyLink>
+    )
+  },
+  strong: function Strong({ children, ...props }) {
+    return (
+      <TypographyBold {...props} className="text-gray-200">
+        {children}
+      </TypographyBold>
+    )
+  },
+  em: function Em({ children, ...props }) {
+    return <TypographyItalic {...props}>{children}</TypographyItalic>
+  },
+  code: function Code({ className, children, ...props }) {
+    const isInline = !className
+    if (isInline) {
+      return (
+        <TypographyInlineCode {...props} className="text-gray-200">
+          {children}
+        </TypographyInlineCode>
+      )
+    }
+    const language = extractLanguage(className)
+    return (
+      <CodeBlock className={className}>
+        <CodeBlockCode code={children as string} language={language} />
+      </CodeBlock>
+    )
+  },
+  pre: function Pre({ children }) {
+    return <>{children}</>
+  },
+}
+
+export function getArticleMDXComponents(
+  components?: Record<string, ComponentType<any>>,
+) {
+  return { ...DEFAULT_ARTICLE_MDX_COMPONENTS, ...components }
+}
+


### PR DESCRIPTION
## Summary
- allow SEO articles to be written in MDX
- expose helper to customize MDX components

## Testing
- `pnpm lint` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_686650812bf8832ebe850525215a7479